### PR TITLE
Fix TIMESTAMPDIFF typo in 08_current_watermark.md

### DIFF
--- a/08_current_watermark.md
+++ b/08_current_watermark.md
@@ -29,7 +29,7 @@ watermarking in action.
 SELECT 
    $rowtime, 
    CURRENT_WATERMARK($rowtime) AS wm, 
-   TIMESTAMPDIFF($rowtime, CURRENT_WATERMARK(`$rowtime`), SECONDS) AS watermark_lag
+   TIMESTAMPDIFF(SECOND, $rowtime, CURRENT_WATERMARK(`$rowtime`)) AS watermark_lag
 FROM clicks;
 ```
 


### PR DESCRIPTION
Changed to TIMESTAMPDIFF(SECOND, $rowtime, CURRENT_WATERMARK($rowtime)) from TIMESTAMPDIFF($rowtime, CURRENT_WATERMARK($rowtime), SECONDS)